### PR TITLE
feat: agregar estandar en las respuestas del api

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { CategoriesModule } from './categories/categories.module';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProductsModule } from './products/products.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ProductsModule } from './products/products.module';
     }),
     CategoriesModule,
     ProductsModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -20,19 +20,19 @@ export class CategoriesController {
   @Post()
   async create(@Body() createCategoryDto: CreateCategoryDto) {
     const category = await this.categoriesService.create(createCategoryDto);
-    return createResponse(category, 'Category created');
+    return createResponse(category, 'Success');
   }
 
   @Get()
   async findAll() {
     const categories = await this.categoriesService.findAll();
-    return createResponse(categories, 'List of categories');
+    return createResponse(categories);
   }
 
   @Get(':id')
   async findOne(@Param('id', ParseIntPipe) id: number) {
     const category = await this.categoriesService.findOne(id);
-    return createResponse(category, 'Category found');
+    return createResponse(category);
   }
 
   @Patch(':id')
@@ -41,12 +41,12 @@ export class CategoriesController {
     @Body() updateCategoryDto: UpdateCategoryDto,
   ) {
     const category = await this.categoriesService.update(id, updateCategoryDto);
-    return createResponse(category, 'Category updated');
+    return createResponse(category);
   }
 
   @Delete(':id')
   async remove(@Param('id', ParseIntPipe) id: number) {
     const category = await this.categoriesService.remove(id);
-    return createResponse(category, 'Category removed');
+    return createResponse(category);
   }
 }

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -11,36 +11,42 @@ import {
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
+import { createResponse } from 'src/common/dto/response-dto';
 
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Post()
-  create(@Body() createCategoryDto: CreateCategoryDto) {
-    return this.categoriesService.create(createCategoryDto);
+  async create(@Body() createCategoryDto: CreateCategoryDto) {
+    const category = await this.categoriesService.create(createCategoryDto);
+    return createResponse(category, 'Category created');
   }
 
   @Get()
-  findAll() {
-    return this.categoriesService.findAll();
+  async findAll() {
+    const categories = await this.categoriesService.findAll();
+    return createResponse(categories, 'List of categories');
   }
 
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.categoriesService.findOne(+id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    const category = await this.categoriesService.findOne(id);
+    return createResponse(category, 'Category found');
   }
 
   @Patch(':id')
-  update(
+  async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateCategoryDto: UpdateCategoryDto,
   ) {
-    return this.categoriesService.update(id, updateCategoryDto);
+    const category = await this.categoriesService.update(id, updateCategoryDto);
+    return createResponse(category, 'Category updated');
   }
 
   @Delete(':id')
-  remove(@Param('id', ParseIntPipe) id: number) {
-    return this.categoriesService.remove(id);
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    const category = await this.categoriesService.remove(id);
+    return createResponse(category, 'Category removed');
   }
 }

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -3,6 +3,7 @@ import { CategoriesService } from './categories.service';
 import { CategoriesController } from './categories.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Category } from './entities/category.entity';
+import { CommonModule } from 'src/common/common.module';
 
 @Module({
   controllers: [CategoriesController],
@@ -10,6 +11,7 @@ import { Category } from './entities/category.entity';
   imports: [
     // Add the TypeOrmModule import
     TypeOrmModule.forFeature([Category]),
+    CommonModule,
   ],
   exports: [CategoriesService],
 })

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  exports: [],
+})
+export class CommonModule {}

--- a/src/common/dto/response-dto.ts
+++ b/src/common/dto/response-dto.ts
@@ -1,0 +1,8 @@
+export class ResponseDto<T> {
+  message: string;
+  data: T;
+}
+
+export function createResponse<T>(data: T, message: string): ResponseDto<T> {
+  return { data, message };
+}

--- a/src/common/dto/response-dto.ts
+++ b/src/common/dto/response-dto.ts
@@ -1,8 +1,11 @@
-export class ResponseDto<T> {
-  message: string;
+export interface ResponseDto<T> {
+  message?: string;
   data: T;
 }
 
-export function createResponse<T>(data: T, message: string): ResponseDto<T> {
+export function createResponse<T>(
+  data: T,
+  message: string = 'OK',
+): ResponseDto<T> {
   return { data, message };
 }

--- a/src/common/utils/db_error_handler.ts
+++ b/src/common/utils/db_error_handler.ts
@@ -1,0 +1,28 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+
+interface DriverError extends Error {
+  length: number;
+  code: string;
+  severity: string;
+  detail: string;
+  schema: string;
+  table: string;
+  constraint: string;
+  file: string;
+  line: string;
+  routine: string;
+}
+
+const mapQueryErrorMessage = (error: QueryFailedError) => {
+  const dbError = error.driverError as DriverError;
+  if (dbError.code === '23505') {
+    return dbError.detail;
+  }
+};
+
+export default function handleDBError(error: Error) {
+  if (error instanceof QueryFailedError) {
+    throw new UnprocessableEntityException(mapQueryErrorMessage(error));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,9 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
     new ValidationPipe({
-      stopAtFirstError: true,
       whitelist: true,
       forbidNonWhitelisted: true,
+      stopAtFirstError: true,
     }),
   );
   console.log('App starting on localhost:3000');

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
     new ValidationPipe({
+      stopAtFirstError: true,
       whitelist: true,
       forbidNonWhitelisted: true,
     }),

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -6,37 +6,47 @@ import {
   Patch,
   Param,
   Delete,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { createResponse } from 'src/common/dto/response-dto';
 
 @Controller('products')
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
   @Post()
-  create(@Body() createProductDto: CreateProductDto) {
-    return this.productsService.create(createProductDto);
+  async create(@Body() createProductDto: CreateProductDto) {
+    const product = await this.productsService.create(createProductDto);
+    return createResponse(product, 'Product created');
   }
 
   @Get()
-  findAll() {
-    return this.productsService.findAll();
+  async findAll() {
+    const products = await this.productsService.findAll();
+    return createResponse(products, 'List of products');
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.productsService.findOne(+id);
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    const product = await this.productsService.findOne(id);
+    return createResponse(product, 'Product found');
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateProductDto: UpdateProductDto) {
-    return this.productsService.update(+id, updateProductDto);
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateProductDto: UpdateProductDto,
+  ) {
+    const product = this.productsService.update(id, updateProductDto);
+    return createResponse(product, 'Product updated');
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.productsService.remove(+id);
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    const product = this.productsService.remove(id);
+    return createResponse(product, 'Product removed');
   }
 }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -20,19 +20,19 @@ export class ProductsController {
   @Post()
   async create(@Body() createProductDto: CreateProductDto) {
     const product = await this.productsService.create(createProductDto);
-    return createResponse(product, 'Product created');
+    return createResponse(product, 'Success');
   }
 
   @Get()
   async findAll() {
     const products = await this.productsService.findAll();
-    return createResponse(products, 'List of products');
+    return createResponse(products);
   }
 
   @Get(':id')
   async findOne(@Param('id', ParseIntPipe) id: number) {
     const product = await this.productsService.findOne(id);
-    return createResponse(product, 'Product found');
+    return createResponse(product);
   }
 
   @Patch(':id')
@@ -41,12 +41,12 @@ export class ProductsController {
     @Body() updateProductDto: UpdateProductDto,
   ) {
     const product = this.productsService.update(id, updateProductDto);
-    return createResponse(product, 'Product updated');
+    return createResponse(product);
   }
 
   @Delete(':id')
   async remove(@Param('id', ParseIntPipe) id: number) {
     const product = this.productsService.remove(id);
-    return createResponse(product, 'Product removed');
+    return createResponse(product);
   }
 }

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
 import { CategoriesService } from 'src/categories/categories.service';
+import handleDBError from 'src/common/utils/db_error_handler';
 
 @Injectable()
 export class ProductsService {
@@ -15,14 +16,18 @@ export class ProductsService {
   ) {}
 
   async create(createProductDto: CreateProductDto) {
-    const category = await this.categoryService.findOne(
-      createProductDto.categoryId,
-    );
-    const product = this.productRepository.create({
-      ...createProductDto,
-      category,
-    });
-    return await this.productRepository.save(product);
+    try {
+      const category = await this.categoryService.findOne(
+        createProductDto.categoryId,
+      );
+      const product = this.productRepository.create({
+        ...createProductDto,
+        category,
+      });
+      return await this.productRepository.save(product);
+    } catch (error) {
+      handleDBError(error);
+    }
   }
 
   async findAll() {


### PR DESCRIPTION
Las respuestas del api quedarán con la siguiente estructura: 

### Errores

La propiedad message puede ser un `string` o un `array` de strings; `statusCode` es un número entero que representa el código de error, y error es un string que indica el mensaje http del error.

```json
{
  "message": "string o arreglo de strings"
  "error": "string"
  "statusCode": 400
}
```
### Respuesta satisfactoria
```json
{
  "message": "string"
  "data": {},
}
```
